### PR TITLE
Rename simple type checker and fix todos

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
-pub mod simple_type_checker;
-pub use simple_type_checker::*;
+pub mod type_checker;
+pub use type_checker::*;
 
 #[cfg(test)]
 mod tests;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,8 @@
 use glsl_lang::ast;
 use glsl_lang::parse::Parsable;
 
-mod simple_type_checker;
-use simple_type_checker::SimpleTypeChecker;
+mod type_checker;
+use type_checker::TypeChecker;
 
 #[allow(clippy::too_many_lines)]
 fn main() {
@@ -97,7 +97,7 @@ fn main() {
                 println!("✓ Parsing successful");
 
                 // Create a type checker and check the AST
-                let mut type_checker = SimpleTypeChecker::new();
+                let mut type_checker = TypeChecker::new();
 
                 match type_checker.check_translation_unit(&translation_unit) {
                     Ok(()) => {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,7 +1,7 @@
 #[cfg(test)]
 #[allow(clippy::module_inception)]
 mod tests {
-    use crate::simple_type_checker::*;
+    use crate::type_checker::*;
     use glsl_lang::ast;
     use glsl_lang::parse::Parsable;
 
@@ -175,7 +175,7 @@ mod tests {
         ";
 
         let translation_unit = ast::TranslationUnit::parse(glsl_code).unwrap();
-        let mut type_checker = SimpleTypeChecker::new();
+        let mut type_checker = TypeChecker::new();
 
         assert!(type_checker
             .check_translation_unit(&translation_unit)
@@ -196,7 +196,7 @@ mod tests {
         ";
 
         let translation_unit = ast::TranslationUnit::parse(glsl_code).unwrap();
-        let mut type_checker = SimpleTypeChecker::new();
+        let mut type_checker = TypeChecker::new();
 
         assert!(type_checker
             .check_translation_unit(&translation_unit)
@@ -215,7 +215,7 @@ mod tests {
         ";
 
         let translation_unit = ast::TranslationUnit::parse(glsl_code).unwrap();
-        let mut type_checker = SimpleTypeChecker::new();
+        let mut type_checker = TypeChecker::new();
 
         let result = type_checker.check_translation_unit(&translation_unit);
         if let Err(errors) = &result {
@@ -240,7 +240,7 @@ mod tests {
         ";
 
         let translation_unit = ast::TranslationUnit::parse(glsl_code).unwrap();
-        let mut type_checker = SimpleTypeChecker::new();
+        let mut type_checker = TypeChecker::new();
 
         let result = type_checker.check_translation_unit(&translation_unit);
         // The simplified type checker may not fully handle function calls,
@@ -258,7 +258,7 @@ mod tests {
         ";
 
         let translation_unit = ast::TranslationUnit::parse(glsl_code).unwrap();
-        let mut type_checker = SimpleTypeChecker::new();
+        let mut type_checker = TypeChecker::new();
 
         let result = type_checker.check_translation_unit(&translation_unit);
         // This might pass in the simplified checker, but demonstrates error testing framework
@@ -303,7 +303,7 @@ mod tests {
 
     #[test]
     fn test_type_checker_new() {
-        let type_checker = SimpleTypeChecker::new();
+        let type_checker = TypeChecker::new();
         assert!(type_checker.errors.is_empty());
         assert!(!type_checker.symbol_table.scopes.is_empty());
         assert!(type_checker.symbol_table.lookup_function("sin").is_some());
@@ -321,7 +321,7 @@ mod tests {
         let empty_glsl = "";
         let translation_unit = ast::TranslationUnit::parse(empty_glsl);
         if let Ok(tu) = translation_unit {
-            let mut type_checker = SimpleTypeChecker::new();
+            let mut type_checker = TypeChecker::new();
             assert!(type_checker.check_translation_unit(&tu).is_ok());
         }
     }
@@ -338,7 +338,7 @@ mod tests {
 
         let translation_unit = ast::TranslationUnit::parse(glsl_code);
         if let Ok(tu) = translation_unit {
-            let mut type_checker = SimpleTypeChecker::new();
+            let mut type_checker = TypeChecker::new();
             // Test that we can handle the parsing even if type checking is simplified
             let _result = type_checker.check_translation_unit(&tu);
         }
@@ -441,7 +441,7 @@ mod tests {
         ";
 
         let translation_unit = ast::TranslationUnit::parse(glsl_code).unwrap();
-        let mut type_checker = SimpleTypeChecker::new();
+        let mut type_checker = TypeChecker::new();
 
         assert!(type_checker
             .check_translation_unit(&translation_unit)


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Rename `SimpleTypeChecker` to `TypeChecker` and enhance function return type validation.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
This PR renames the `simple_type_checker` module and `SimpleTypeChecker` struct to `type_checker` and `TypeChecker` respectively, along with updating all references. A type alias `SimpleTypeChecker = TypeChecker` is added for backward compatibility. Additionally, it addresses several TODOs, most notably implementing proper function return type validation, including handling void functions and type compatibility checks.

---
<a href="https://cursor.com/background-agent?bcId=bc-04a13635-79c3-40b0-b682-74ed69dccd36">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-04a13635-79c3-40b0-b682-74ed69dccd36">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>