### PR TITLE
Make shader type a translator parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ A comprehensive type checking system for OpenGL Shading Language (GLSL) built in
 - **Function Name Mapping**: 
   - `fract()` → `frac()`, `mix()` → `lerp()`, `inversesqrt()` → `rsqrt()`
 - **Semantic Annotation**: Automatic generation of HLSL semantics
-- **Shader Type Detection**: Intelligent detection and appropriate main function generation
+- **Shader Type Detection**: Intelligent auto-detection or explicit specification for precise control
 - **Cross-Platform Compatibility**: Write once in GLSL, deploy to both OpenGL and DirectX
 
 ## Installation
@@ -110,9 +110,22 @@ fn main() {
     match ast::TranslationUnit::parse(glsl_code) {
         Ok(translation_unit) => {
             let mut translator = HLSLTranslator::new();
+            
+            // Option 1: Auto-detect shader type (existing functionality)
             match translator.translate_translation_unit(&translation_unit) {
                 Ok(hlsl_code) => {
-                    println!("HLSL Translation:");
+                    println!("HLSL Translation (auto-detected):");
+                    println!("{}", hlsl_code);
+                }
+                Err(error) => {
+                    println!("Translation error: {}", error);
+                }
+            }
+            
+            // Option 2: Specify shader type explicitly (new functionality)
+            match translator.translate_translation_unit_with_type(&translation_unit, ShaderType::Fragment) {
+                Ok(hlsl_code) => {
+                    println!("HLSL Translation (explicit fragment shader):");
                     println!("{}", hlsl_code);
                 }
                 Err(error) => {
@@ -329,10 +342,13 @@ Main type checking engine:
 #### `HLSLTranslator` ⭐ **NEW**
 HLSL translation engine:
 - `new()` - Create a new HLSL translator
-- `translate_translation_unit(ast)` - Translate GLSL AST to HLSL code
+- `translate_translation_unit(ast)` - Translate GLSL AST to HLSL code (auto-detects shader type)
+- `translate_translation_unit_with_type(ast, shader_type)` - Translate GLSL AST to HLSL code with explicit shader type
 - `map_function_name(glsl_name)` - Map GLSL function to HLSL equivalent
 - `map_builtin_variable(glsl_var)` - Map GLSL built-in to HLSL semantic
 - Returns `Result<String, String>` with translated HLSL code or error
+
+**Shader Types**: `ShaderType::Vertex`, `ShaderType::Fragment`, `ShaderType::Compute`, `ShaderType::Unknown`
 
 #### `SymbolTable`
 Manages variable and function scopes:

--- a/src/hlsl_translator.rs
+++ b/src/hlsl_translator.rs
@@ -259,6 +259,21 @@ impl HLSLTranslator {
         Ok(self.output.clone())
     }
 
+    /// Translate a GLSL translation unit to HLSL with a specified shader type
+    pub fn translate_translation_unit_with_type(&mut self, unit: &ast::TranslationUnit, shader_type: ShaderType) -> Result<String, String> {
+        self.output.clear();
+        self.indent_level = 0;
+
+        // Use the provided shader type instead of detecting it
+        self.current_shader_type = shader_type;
+
+        for external_decl in &unit.0 {
+            self.translate_external_declaration(external_decl)?;
+        }
+
+        Ok(self.output.clone())
+    }
+
     /// Detect the type of shader based on the AST content
     fn detect_shader_type(&mut self, unit: &ast::TranslationUnit) {
         // Simple heuristic: look for main function and typical variables

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -954,4 +954,52 @@ mod hlsl_translation_tests {
             }
         }
     }
+
+    #[test]
+    fn test_translate_with_shader_type_parameter() {
+        let glsl_code = r"
+            void main() {
+                vec4 color = vec4(1.0, 0.5, 0.2, 1.0);
+            }
+        ";
+        
+        let translation_unit = ast::TranslationUnit::parse(glsl_code)
+            .expect("GLSL code should parse successfully");
+        
+        let mut translator = HLSLTranslator::new();
+        
+        // Test with explicit vertex shader type
+        let hlsl_vertex = translator.translate_translation_unit_with_type(&translation_unit, ShaderType::Vertex)
+            .expect("Translation with vertex shader type should succeed");
+        
+        // Reset translator for next test
+        translator = HLSLTranslator::new();
+        
+        // Test with explicit fragment shader type
+        let hlsl_fragment = translator.translate_translation_unit_with_type(&translation_unit, ShaderType::Fragment)
+            .expect("Translation with fragment shader type should succeed");
+        
+        // Reset translator for next test
+        translator = HLSLTranslator::new();
+        
+        // Test with compute shader type
+        let hlsl_compute = translator.translate_translation_unit_with_type(&translation_unit, ShaderType::Compute)
+            .expect("Translation with compute shader type should succeed");
+        
+        // Verify that the shader type affects the translation (at minimum, the output should not be empty)
+        assert!(!hlsl_vertex.is_empty(), "Vertex shader translation should not be empty");
+        assert!(!hlsl_fragment.is_empty(), "Fragment shader translation should not be empty");
+        assert!(!hlsl_compute.is_empty(), "Compute shader translation should not be empty");
+        
+        // Verify that the translator's current_shader_type is set correctly
+        translator = HLSLTranslator::new();
+        let _ = translator.translate_translation_unit_with_type(&translation_unit, ShaderType::Vertex);
+        assert_eq!(translator.current_shader_type, ShaderType::Vertex);
+        
+        let _ = translator.translate_translation_unit_with_type(&translation_unit, ShaderType::Fragment);
+        assert_eq!(translator.current_shader_type, ShaderType::Fragment);
+        
+        let _ = translator.translate_translation_unit_with_type(&translation_unit, ShaderType::Compute);
+        assert_eq!(translator.current_shader_type, ShaderType::Compute);
+    }
 }


### PR DESCRIPTION
Add `translate_translation_unit_with_type` to allow explicit shader type specification for more accurate HLSL translation.

---
<a href="https://cursor.com/background-agent?bcId=bc-7754f984-81c3-4c77-a491-03f619383682">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7754f984-81c3-4c77-a491-03f619383682">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>