### PR TITLE
Remove shader type auto detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ A comprehensive type checking system for OpenGL Shading Language (GLSL) built in
 - **Function Name Mapping**: 
   - `fract()` → `frac()`, `mix()` → `lerp()`, `inversesqrt()` → `rsqrt()`
 - **Semantic Annotation**: Automatic generation of HLSL semantics
-- **Shader Type Detection**: Intelligent auto-detection or explicit specification for precise control
+- **Explicit Shader Type Specification**: Precise control with required explicit shader type specification
 - **Cross-Platform Compatibility**: Write once in GLSL, deploy to both OpenGL and DirectX
 
 ## Installation
@@ -111,21 +111,10 @@ fn main() {
         Ok(translation_unit) => {
             let mut translator = HLSLTranslator::new();
             
-            // Option 1: Auto-detect shader type (existing functionality)
-            match translator.translate_translation_unit(&translation_unit) {
-                Ok(hlsl_code) => {
-                    println!("HLSL Translation (auto-detected):");
-                    println!("{}", hlsl_code);
-                }
-                Err(error) => {
-                    println!("Translation error: {}", error);
-                }
-            }
-            
-            // Option 2: Specify shader type explicitly (new functionality)
+            // Specify shader type explicitly (required)
             match translator.translate_translation_unit_with_type(&translation_unit, ShaderType::Fragment) {
                 Ok(hlsl_code) => {
-                    println!("HLSL Translation (explicit fragment shader):");
+                    println!("HLSL Translation (fragment shader):");
                     println!("{}", hlsl_code);
                 }
                 Err(error) => {
@@ -342,7 +331,7 @@ Main type checking engine:
 #### `HLSLTranslator` ⭐ **NEW**
 HLSL translation engine:
 - `new()` - Create a new HLSL translator
-- `translate_translation_unit(ast)` - Translate GLSL AST to HLSL code (auto-detects shader type)
+- `translate_translation_unit(ast)` - **DEPRECATED**: Returns error, use translate_translation_unit_with_type instead
 - `translate_translation_unit_with_type(ast, shader_type)` - Translate GLSL AST to HLSL code with explicit shader type
 - `map_function_name(glsl_name)` - Map GLSL function to HLSL equivalent
 - `map_builtin_variable(glsl_var)` - Map GLSL built-in to HLSL semantic

--- a/src/hlsl_translator.rs
+++ b/src/hlsl_translator.rs
@@ -244,19 +244,10 @@ impl HLSLTranslator {
         });
     }
 
-    /// Translate a GLSL translation unit to HLSL
-    pub fn translate_translation_unit(&mut self, unit: &ast::TranslationUnit) -> Result<String, String> {
-        self.output.clear();
-        self.indent_level = 0;
-
-        // Detect shader type from function names and built-ins
-        self.detect_shader_type(unit);
-
-        for external_decl in &unit.0 {
-            self.translate_external_declaration(external_decl)?;
-        }
-
-        Ok(self.output.clone())
+    /// Translate a GLSL translation unit to HLSL with explicit shader type requirement
+    /// Note: This method requires an explicit shader type. Use translate_translation_unit_with_type instead.
+    pub fn translate_translation_unit(&mut self, _unit: &ast::TranslationUnit) -> Result<String, String> {
+        return Err("Shader type auto-detection has been removed. Please use translate_translation_unit_with_type() and specify an explicit shader type.".to_string());
     }
 
     /// Translate a GLSL translation unit to HLSL with a specified shader type
@@ -274,20 +265,7 @@ impl HLSLTranslator {
         Ok(self.output.clone())
     }
 
-    /// Detect the type of shader based on the AST content
-    fn detect_shader_type(&mut self, unit: &ast::TranslationUnit) {
-        // Simple heuristic: look for main function and typical variables
-        for external_decl in &unit.0 {
-            if let ast::ExternalDeclarationData::FunctionDefinition(func_def) = &external_decl.content {
-                let func_name = &func_def.content.prototype.content.name.content.0;
-                if func_name == "main" {
-                    // Check the function body for shader-specific built-ins
-                    // This is a simplified detection - in practice you might need more sophisticated logic
-                    self.current_shader_type = ShaderType::Fragment; // Default assumption
-                }
-            }
-        }
-    }
+
 
     /// Translate an external declaration
     fn translate_external_declaration(&mut self, decl: &ast::Node<ast::ExternalDeclarationData>) -> Result<(), String> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -78,7 +78,13 @@ fn main() {
                         // Try HLSL translation
                         println!("\n--- HLSL Translation ---");
                         let mut hlsl_translator = HLSLTranslator::new();
-                        match hlsl_translator.translate_translation_unit(&translation_unit) {
+                        // Determine shader type based on test name or content
+                        let shader_type = if test_name.contains("vertex") {
+                            hlsl_translator::ShaderType::Vertex
+                        } else {
+                            hlsl_translator::ShaderType::Fragment
+                        };
+                        match hlsl_translator.translate_translation_unit_with_type(&translation_unit, shader_type) {
                             Ok(hlsl_code) => {
                                 println!("✓ HLSL translation successful!");
                                 println!("HLSL Output:");
@@ -158,7 +164,8 @@ fn main() {
         match ast::TranslationUnit::parse(glsl_code) {
             Ok(translation_unit) => {
                 let mut hlsl_translator = HLSLTranslator::new();
-                match hlsl_translator.translate_translation_unit(&translation_unit) {
+                // Default to fragment shader for test examples
+                match hlsl_translator.translate_translation_unit_with_type(&translation_unit, hlsl_translator::ShaderType::Fragment) {
                     Ok(hlsl_code) => {
                         println!("GLSL Input:");
                         println!("{}", glsl_code.trim());

--- a/src/stress_tests.rs
+++ b/src/stress_tests.rs
@@ -16,7 +16,8 @@ mod stress_tests {
         match ast::TranslationUnit::parse(glsl_code) {
             Ok(translation_unit) => {
                 let mut translator = HLSLTranslator::new();
-                match translator.translate_translation_unit(&translation_unit) {
+                // Default to fragment shader for stress tests
+                match translator.translate_translation_unit_with_type(&translation_unit, ShaderType::Fragment) {
                     Ok(hlsl_code) => {
                         if should_succeed {
                             println!("✓ Translation succeeded");


### PR DESCRIPTION
Remove shader type auto-detection to enforce explicit shader type specification.

The `translate_translation_unit` method now returns an error, requiring users to explicitly specify the shader type using `translate_translation_unit_with_type` for all translations.

---
<a href="https://cursor.com/background-agent?bcId=bc-c0b98421-9d64-44f0-8460-d8781d4f60bb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c0b98421-9d64-44f0-8460-d8781d4f60bb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>